### PR TITLE
Removed unused argument 'strength' from LTXVImgToVideo.generate() method

### DIFF
--- a/easy_samplers.py
+++ b/easy_samplers.py
@@ -132,8 +132,7 @@ class LTXVBaseSampler:
                 width=width,
                 height=height,
                 length=num_frames,
-                batch_size=1,
-                strength=strength,
+                batch_size=1
             )
         else:
             (latents,) = EmptyLTXVLatentVideo().generate(width, height, num_frames, 1)


### PR DESCRIPTION
When doing i2v the flow breaks at the LTXV Base Sampler node 
![image](https://github.com/user-attachments/assets/7feb8bea-7fb1-4717-b33d-38792fbf8df8)

This happens because the strength value gets passed to `LTXVImgToVideo().generate` which doesn't use it.

So in this PR I simply removed the `strength` in that method. And now the i2v flow runs correctly for me.