### PR TITLE
feat: added dynamic resolution for easy samplers

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,5 @@
 from .decoder_noise import DecoderNoise
+from .dynamic_resolution import LTX_DynamicResolutionSelector
 from .easy_samplers import (
     LinearOverlapLatentTransition,
     LTXVBaseSampler,
@@ -60,6 +61,7 @@ NODE_CLASS_MAPPINGS = {
     "STGGuiderNode": STGGuiderNode,
     "LTXVMultiPromptProvider": MultiPromptProvider,
     "ImageToCPU": ImageToCPU,
+    "LTX_DynamicResolutionSelector": LTX_DynamicResolutionSelector,
 }
 
 # Consistent display names between static and dynamic node mappings in nodes_registry.py,
@@ -68,6 +70,9 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     name: f"{NODES_DISPLAY_NAME_PREFIX} {camel_case_to_spaces(name)}"
     for name in NODE_CLASS_MAPPINGS.keys()
 }
+
+# Add custom display name for our new node
+NODE_DISPLAY_NAME_MAPPINGS["LTX_DynamicResolutionSelector"] = "LTX Dynamic Resolution Selector"
 
 # Merge the node mappings from tricks into the main mappings
 NODE_CLASS_MAPPINGS.update(TRICKS_NODE_CLASS_MAPPINGS)

--- a/dynamic_resolution.py
+++ b/dynamic_resolution.py
@@ -1,0 +1,63 @@
+import torch
+
+class LTX_DynamicResolutionSelector:
+    
+    RESOLUTIONS_720P = {
+        "9:16": (704, 1216),
+        "16:9": (1216, 704),
+        "1:1":  (960, 960),
+        "3:4":  (912, 1216),
+        "4:3":  (1216, 912)
+    }
+    
+    RESOLUTIONS_512P = {
+        "9:16": (384, 672),
+        "16:9": (672, 384),
+        "1:1":  (512, 512),
+        "3:4":  (448, 576),
+        "4:3":  (576, 416)
+    }
+
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "image": ("IMAGE",),
+                "resolution_preset": (["720p", "512p"], {"default": "720p"}),
+            }
+        }
+
+    RETURN_TYPES = ("INT", "INT")
+    RETURN_NAMES = ("width", "height")
+    FUNCTION = "get_resolution"
+    CATEGORY = "LTX Custom Logic"
+
+    def get_resolution(self, image, resolution_preset):
+        _ , height, width, _ = image.shape
+        
+        if resolution_preset == "720p":
+            resolution_map = self.RESOLUTIONS_720P
+        else: # "512p"
+            resolution_map = self.RESOLUTIONS_512P
+
+        if height == 0:
+            input_ratio = 1.777
+        else:
+            input_ratio = width / height
+            
+        best_match_key = None
+        min_diff = float('inf')
+
+        for key, (res_w, res_h) in resolution_map.items():
+            supported_ratio = res_w / res_h
+            diff = abs(input_ratio - supported_ratio)
+            
+            if diff < min_diff:
+                min_diff = diff
+                best_match_key = key
+        
+        final_width, final_height = resolution_map[best_match_key]
+        
+        print(f"[DynamicResolution] Preset: {resolution_preset} | Input: {width}x{height} -> Best Match: {best_match_key} -> Output: {final_width}x{final_height}")
+        
+        return (final_width, final_height)

--- a/easy_samplers.py
+++ b/easy_samplers.py
@@ -56,6 +56,18 @@ class LTXVBaseSampler:
                 "noise": ("NOISE", {"tooltip": "The noise to use for the sampling."}),
             },
             "optional": {
+                "dynamic_width": (
+                    "INT",
+                    {
+                        "tooltip": "If provided, this width will override the width parameter."
+                    },
+                ),
+                "dynamic_height": (
+                    "INT",
+                    {
+                        "tooltip": "If provided, this height will override the height parameter."
+                    },
+                ),
                 "optional_cond_images": (
                     "IMAGE",
                     {"tooltip": "The images to use for conditioning the sampling."},
@@ -119,6 +131,8 @@ class LTXVBaseSampler:
         sampler,
         sigmas,
         noise,
+        dynamic_width=None,
+        dynamic_height=None,
         optional_cond_images=None,
         optional_cond_indices=None,
         strength=0.9,
@@ -130,6 +144,11 @@ class LTXVBaseSampler:
         optional_negative_index_strength=1.0,
         optional_initialization_latents=None,
     ):
+        # Override width and height if dynamic values are provided
+        if dynamic_width is not None:
+            width = dynamic_width
+        if dynamic_height is not None:
+            height = dynamic_height
 
         if optional_cond_images is not None:
             optional_cond_images = (


### PR DESCRIPTION
This PR adds dynamic resolution support to LTXVBaseSampler. Users can now automatically select appropriate resolutions based on input image aspect ratios.

  Features:
  - Added LTX_DynamicResolutionSelector node - suggests appropriate resolution based on input image aspect ratio
  - Added optional dynamic_width and dynamic_height parameters to LTXVBaseSampler
  - When dynamic parameters are provided, they override default width/height values

  Usage:
  1. Load an image
  2. Use LTX_DynamicResolutionSelector to determine appropriate resolution
  3. Connect outputs to LTXVBaseSampler's dynamic inputs