### PR TITLE
Add MPS support to the gemma node

### DIFF
--- a/gemma_encoder.py
+++ b/gemma_encoder.py
@@ -597,10 +597,11 @@ class LTXVGemmaCLIPModelLoader:
 
         clip_dtype = torch.bfloat16
         try:
+            # MPS does not have full support bfloat16, use float16 instead
             if comfy.model_management.get_torch_device().type == "mps":
                 clip_dtype = torch.float16
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(f"Could not detect device type for dtype selection: {e}")
 
         ltxv_full_path = folder_paths.get_full_path("checkpoints", ltxv_path)
         clip_target = comfy.supported_models_base.ClipTarget(

--- a/gemma_encoder.py
+++ b/gemma_encoder.py
@@ -3,15 +3,8 @@ import logging
 from pathlib import Path
 from typing import Optional
 
-import comfy.model_management
-import comfy.ops
-import comfy.sd
-import comfy.supported_models_base
-import folder_paths
 import safetensors
 import torch
-from comfy.ldm.lightricks.model import LTXFrequenciesPrecision, LTXRopeType
-from comfy.utils import load_torch_file
 from einops import rearrange
 from PIL import Image
 from transformers import (
@@ -20,6 +13,14 @@ from transformers import (
     Gemma3ForConditionalGeneration,
     Gemma3Processor,
 )
+
+import comfy.model_management
+import comfy.ops
+import comfy.sd
+import comfy.supported_models_base
+import folder_paths
+from comfy.ldm.lightricks.model import LTXFrequenciesPrecision, LTXRopeType
+from comfy.utils import load_torch_file
 
 from .embeddings_connector import Embeddings1DConnector
 from .nodes_registry import comfy_node
@@ -429,7 +430,8 @@ class LTXVGemmaTextEncoderModel(torch.nn.Module):
         ).to(self.model.device)
         model_inputs = self._pad_inputs_for_attention_alignment(model_inputs)
 
-        with torch.inference_mode(), torch.random.fork_rng(devices=[self.model.device]):
+        devices = [self.model.device] if self.model.device.type == "cuda" else []
+        with torch.inference_mode(), torch.random.fork_rng(devices=devices):
             torch.manual_seed(seed)
             outputs = self.model.generate(
                 **model_inputs,
@@ -493,7 +495,9 @@ def ltxv_gemma_tokenizer(tokenizer_path, max_length=256):
 def ltxv_gemma_clip(encoder_path, ltxv_path, processor=None, dtype=None):
     class _LTXVGemmaTextEncoderModel(LTXVGemmaTextEncoderModel):
         def __init__(self, device="cpu", dtype=dtype, model_options={}):
-            dtype = torch.bfloat16  # TODO: make this configurable
+            if dtype is None:
+                dtype = torch.bfloat16
+
             gemma_model = Gemma3ForConditionalGeneration.from_pretrained(
                 encoder_path,
                 local_files_only=True,
@@ -509,8 +513,12 @@ def ltxv_gemma_clip(encoder_path, ltxv_path, processor=None, dtype=None):
                     encoder_path / "proj_linear.safetensors"
                 )
 
-            embeddings_connector = load_video_embeddings_connector(ltxv_path)
-            audio_embeddings_connector = load_audio_embeddings_connector(ltxv_path)
+            embeddings_connector = load_video_embeddings_connector(
+                ltxv_path, dtype=dtype
+            )
+            audio_embeddings_connector = load_audio_embeddings_connector(
+                ltxv_path, dtype=dtype
+            )
             super().__init__(
                 model=gemma_model,
                 feature_extractor_linear=feature_extractor_linear,
@@ -588,6 +596,12 @@ class LTXVGemmaCLIPModelLoader:
             logger.warning(f"Could not load processor from {model_root}: {e}")
 
         clip_dtype = torch.bfloat16
+        try:
+            if comfy.model_management.get_torch_device().type == "mps":
+                clip_dtype = torch.float16
+        except Exception:
+            pass
+
         ltxv_full_path = folder_paths.get_full_path("checkpoints", ltxv_path)
         clip_target = comfy.supported_models_base.ClipTarget(
             tokenizer=tokenizer_class,

--- a/gemma_encoder.py
+++ b/gemma_encoder.py
@@ -171,7 +171,8 @@ def ltxv_gemma_tokenizer(tokenizer_path, max_length=256):
 def ltxv_gemma_clip(encoder_path, ltxv_path, processor=None, dtype=None):
     class _LTXVGemmaTextEncoderModel(LTXVGemmaTextEncoderModel):
         def __init__(self, device="cpu", dtype=dtype, model_options={}):
-            dtype = torch.bfloat16  # TODO: make this configurable
+            if dtype is None:
+                dtype = torch.bfloat16
 
             gemma_model = Gemma3ForConditionalGeneration.from_pretrained(
                 encoder_path,
@@ -264,6 +265,13 @@ class LTXVGemmaCLIPModelLoader:
             logger.warning(f"Could not load processor from {model_root}: {e}")
 
         clip_dtype = torch.bfloat16
+        try:
+            # MPS does not have full support bfloat16, use float16 instead
+            if comfy.model_management.get_torch_device().type == "mps":
+                clip_dtype = torch.float16
+        except Exception as e:
+            logger.debug(f"Could not detect device type for dtype selection: {e}")
+
         ltxv_full_path = folder_paths.get_full_path("checkpoints", ltxv_path)
         clip_target = comfy.supported_models_base.ClipTarget(
             tokenizer=tokenizer_class,
@@ -428,9 +436,10 @@ def _enhance(
     )
     model_inputs = _pad_inputs_for_attention_alignment(model_inputs, pad_token_id)
 
+    devices = [model.device] if model.device.type == "cuda" else []
     with (
         torch.inference_mode(),
-        torch.random.fork_rng(devices=[model.device]),
+        torch.random.fork_rng(devices=devices),
         torch.autocast(device_type=model.device.type, dtype=model.dtype),
     ):
         torch.manual_seed(seed)

--- a/gemma_encoder.py
+++ b/gemma_encoder.py
@@ -270,7 +270,9 @@ class LTXVGemmaCLIPModelLoader:
             if comfy.model_management.get_torch_device().type == "mps":
                 clip_dtype = torch.float16
         except Exception as e:
-            logger.debug(f"Could not detect device type for dtype selection: {e}")
+            logger.debug(
+                f"Could not detect device type for dtype selection: {e}", exc_info=True
+            )
 
         ltxv_full_path = folder_paths.get_full_path("checkpoints", ltxv_path)
         clip_target = comfy.supported_models_base.ClipTarget(


### PR DESCRIPTION
Adds MPS (Apple Silicon) support to the Gemma text-encoder node.

Related to #302 (gemma text-encoder portion of MPS support)

## Changes

- **`fork_rng` device guard** — `torch.random.fork_rng(devices=[...])` only
  accepts CUDA devices; on MPS it raises. The device list is now passed only
  when the model is on CUDA. Seeded generation on CUDA is unchanged.
- **Respect caller-provided `dtype`** — `_LTXVGemmaTextEncoderModel.__init__`
  previously hardcoded `torch.bfloat16`, overwriting the `dtype` argument;
  it's now only the default. With this, `clip_dtype` flows through
  `ltxv_gemma_clip` into the model and the `load_text_embeddings_pipeline`
  loaders.
- **float16 on MPS** — MPS has incomplete bfloat16 support, so `clip_dtype`
  falls back to `float16` when the torch device is MPS (CUDA keeps
  `bfloat16`). This also keeps the new `torch.autocast(dtype=model.dtype)`
  context in `_enhance` on a dtype MPS actually supports.

Rebased onto current master (single commit, one file, +11/−2). An earlier
revision also propagated `dtype` into the embeddings connectors; that's no
longer needed — the `load_text_embeddings_pipeline` refactor on master
already threads it through.

## Testing status

- Logic verified against PyTorch's `fork_rng` device constraints; the CUDA
  path is preserved unchanged.
- I don't have the models locally for an end-to-end run — verification on
  Apple Silicon welcome.
