### PR TITLE
Refactor: Unify and organize node categories

### DIFF
--- a/conditioning_loader.py
+++ b/conditioning_loader.py
@@ -20,7 +20,7 @@ class LTXVLoadConditioning(io.ComfyNode):
         return io.Schema(
             node_id="LTXVLoadConditioning",
             display_name="🅛🅣🅧 LTXV Load Conditioning",
-            category="lightricks/LTXV",
+            category="Lightricks/LTXV/Conditioning",
             inputs=[
                 io.Combo.Input("file_name", options=sorted(files)),
                 io.Combo.Input("device", options=["cpu", "gpu"]),

--- a/conditioning_saver.py
+++ b/conditioning_saver.py
@@ -16,7 +16,7 @@ class LTXVSaveConditioning(io.ComfyNode):
         return io.Schema(
             node_id="LTXVSaveConditioning",
             display_name="🅛🅣🅧 LTXV Save Conditioning",
-            category="lightricks/LTXV",
+            category="Lightricks/LTXV/Conditioning",
             inputs=[
                 io.Conditioning.Input("conditioning"),
                 io.String.Input("filename", default="conditioning"),

--- a/decoder_noise.py
+++ b/decoder_noise.py
@@ -44,7 +44,7 @@ class DecoderNoise:
 
     FUNCTION = "add_noise"
     RETURN_TYPES = ("VAE",)
-    CATEGORY = "lightricks/LTXV"
+    CATEGORY = "Lightricks/LTXV/Latent"
 
     def add_noise(self, vae, timestep, scale, seed):
         result = copy(vae)

--- a/dynamic_conditioning.py
+++ b/dynamic_conditioning.py
@@ -17,7 +17,7 @@ class DynamicConditioning:
 
     RETURN_TYPES = ("MODEL",)
     FUNCTION = "apply"
-    CATEGORY = "lightricks/LTXV"
+    CATEGORY = "Lightricks/LTXV/Conditioning"
     INIT = False
 
     def apply(self, model, power, only_first_frame):

--- a/easy_samplers.py
+++ b/easy_samplers.py
@@ -123,7 +123,7 @@ class LTXVBaseSampler:
     RETURN_TYPES = ("LATENT", "CONDITIONING", "CONDITIONING")
     RETURN_NAMES = ("denoised", "positive", "negative")
     FUNCTION = "sample"
-    CATEGORY = "sampling"
+    CATEGORY = "Lightricks/LTXV/Sampling"
 
     def sample(
         self,
@@ -371,7 +371,7 @@ class LTXVExtendSampler:
     RETURN_TYPES = ("LATENT", "CONDITIONING", "CONDITIONING")
     RETURN_NAMES = ("denoised_video", "positive", "negative")
     FUNCTION = "sample"
-    CATEGORY = "sampling"
+    CATEGORY = "Lightricks/LTXV/Sampling"
 
     def sample(
         self,
@@ -671,7 +671,7 @@ class LTXVInContextSampler:
     RETURN_TYPES = ("LATENT", "CONDITIONING", "CONDITIONING")
     RETURN_NAMES = ("denoised_video", "positive", "negative")
     FUNCTION = "sample"
-    CATEGORY = "sampling"
+    CATEGORY = "Lightricks/LTXV/Sampling"
 
     def sample(
         self,
@@ -861,7 +861,7 @@ class LinearOverlapLatentTransition:
     RETURN_TYPES = ("LATENT",)
     FUNCTION = "process"
 
-    CATEGORY = "Lightricks/latent"
+    CATEGORY = "Lightricks/LTXV/Utility"
 
     def get_subbatch(self, samples):
         s = samples.copy()
@@ -918,7 +918,7 @@ class LTXVNormalizingSampler(io.ComfyNode):
     def define_schema(cls):
         return io.Schema(
             node_id="LTXVNormalizingSampler",
-            category="utility",
+            category="Lightricks/LTXV/Sampling",
             inputs=[
                 io.Noise.Input("noise"),
                 io.Guider.Input("guider"),

--- a/gemma_api_conditioning.py
+++ b/gemma_api_conditioning.py
@@ -88,7 +88,7 @@ class GemmaAPITextEncode:
     RETURN_TYPES = ("CONDITIONING",)
     RETURN_NAMES = ("conditioning",)
     FUNCTION = "encode"
-    CATEGORY = "api node/text/Lightricks"
+    CATEGORY = "Lightricks/LTXV/Conditioning"
 
     def encode(self, api_key: str, prompt: str, ckpt_name: str):
         if not api_key:

--- a/gemma_encoder.py
+++ b/gemma_encoder.py
@@ -438,7 +438,7 @@ class LTXVGemmaCLIPModelLoader:
     RETURN_TYPES = ("CLIP",)
     RETURN_NAMES = ("clip",)
     FUNCTION = "load_model"
-    CATEGORY = "lightricks/LTXV"
+    CATEGORY = "Lightricks/LTXV/Loaders"
     TITLE = "LTXV Gemma CLIP Loader"
     OUTPUT_NODE = False
 
@@ -526,7 +526,7 @@ class LTXVGemmaEnhancePrompt:
     RETURN_TYPES = ("STRING",)
     RETURN_NAMES = ("enhanced_prompt",)
     FUNCTION = "enhance"
-    CATEGORY = "lightricks/LTXV"
+    CATEGORY = "Lightricks/LTXV/Conditioning"
     TITLE = "LTXV Gemma Enhance Prompt"
     OUTPUT_NODE = True
     DESCRIPTION = (

--- a/guide.py
+++ b/guide.py
@@ -88,7 +88,7 @@ class LTXVAddGuideAdvanced:
     RETURN_TYPES = ("CONDITIONING", "CONDITIONING", "LATENT")
     RETURN_NAMES = ("positive", "negative", "latent")
 
-    CATEGORY = "conditioning/video_models"
+    CATEGORY = "Lightricks/LTXV/Conditioning"
     FUNCTION = "generate"
 
     DESCRIPTION = (
@@ -210,7 +210,7 @@ class LTXVImgToVideoAdvanced:
     RETURN_TYPES = ("CONDITIONING", "CONDITIONING", "LATENT")
     RETURN_NAMES = ("positive", "negative", "latent")
 
-    CATEGORY = "conditioning/video_models"
+    CATEGORY = "Lightricks/LTXV/Conditioning"
     FUNCTION = "generate"
 
     DESCRIPTION = (

--- a/guiders/multimodal_guider.py
+++ b/guiders/multimodal_guider.py
@@ -301,7 +301,7 @@ class MultimodalGuiderNode:
     RETURN_TYPES = ("GUIDER",)
 
     FUNCTION = "get_guider"
-    CATEGORY = "lightricks/LTXV"
+    CATEGORY = "Lightricks/LTXV/Guidance"
 
     def get_guider(self, model, positive, negative, parameters, skip_blocks):
         skip_blocks = [int(n.strip()) for n in skip_blocks.split(",") if n.strip()]

--- a/guiders/parameters.py
+++ b/guiders/parameters.py
@@ -128,7 +128,7 @@ class GuiderParametersNode:
     RETURN_TYPES = ("GUIDER_PARAMETERS",)
 
     FUNCTION = "get_parameters"
-    CATEGORY = "lightricks/LTXV"
+    CATEGORY = "Lightricks/LTXV/Guidance"
 
     def get_parameters(
         self,

--- a/iclora.py
+++ b/iclora.py
@@ -19,7 +19,7 @@ class LTXAddVideoICLoRAGuide(io.ComfyNode):
         return io.Schema(
             node_id="LTXAddVideoICLoRAGuide",
             display_name=NODES_DISPLAY_NAME_PREFIX + " Add Video IC-LoRA Guide",
-            category="Lightricks/IC-LoRA",
+            category="Lightricks/LTXV/Guidance",
             description=(
                 "Adds one or more conditioning frames starting at the specified frame index. "
                 "Supports both single images and multi-frame videos. "
@@ -226,7 +226,7 @@ class LTXICLoRALoaderModelOnly(io.ComfyNode):
         return io.Schema(
             node_id="LTXICLoRALoaderModelOnly",
             display_name=NODES_DISPLAY_NAME_PREFIX + " IC-LoRA Loader Model Only",
-            category="Lightricks/IC-LoRA",
+            category="Lightricks/LTXV/Loaders",
             description="Loads a LoRA model and extracts the latent_downscale_factor from the safetensors metadata.",
             inputs=[
                 io.Model.Input("model"),

--- a/latent_norm.py
+++ b/latent_norm.py
@@ -37,7 +37,7 @@ class LTXVAdainLatent:
     RETURN_TYPES = ("LATENT",)
     FUNCTION = "batch_normalize"
 
-    CATEGORY = "Lightricks/latents"
+    CATEGORY = "Lightricks/LTXV/Latent"
 
     def batch_normalize(self, latents, reference, factor, per_frame=False):
         latents_copy = copy.deepcopy(latents)
@@ -129,7 +129,7 @@ class LTXVStatNormLatent:
     RETURN_TYPES = ("LATENT",)
     FUNCTION = "statistical_normalize"
 
-    CATEGORY = "Lightricks/latents"
+    CATEGORY = "Lightricks/LTXV/Latent"
 
     def statistical_normalize(
         self, latents, target_mean, target_std, percentile, factor, clip_outliers
@@ -262,7 +262,7 @@ class LTXVPerStepAdainPatcher(PerStepNormPatcher):
     RETURN_TYPES = ("MODEL",)
     FUNCTION = "patch_model"
 
-    CATEGORY = "Lightricks/latents"
+    CATEGORY = "Lightricks/LTXV/Model Patches"
 
     def patch_model(self, model, factors, reference, per_frame=False):
         def cfg_adain(latent, factor):
@@ -318,7 +318,7 @@ class LTXVPerStepStatNormPatcher(PerStepNormPatcher):
     RETURN_TYPES = ("MODEL",)
     FUNCTION = "patch_model"
 
-    CATEGORY = "Lightricks/latents"
+    CATEGORY = "Lightricks/LTXV/Model Patches"
 
     def patch_model(
         self, model, factors, target_mean, target_std, percentile, clip_outliers

--- a/latents.py
+++ b/latents.py
@@ -40,7 +40,7 @@ class LTXVSelectLatents:
 
     RETURN_TYPES = ("LATENT",)
     FUNCTION = "select_latents"
-    CATEGORY = "latent/video"
+    CATEGORY = "Lightricks/LTXV/Latent"
     DESCRIPTION = (
         "Selects a range of frames from the video latent. "
         "start_index and end_index define a closed interval (inclusive of both endpoints)."
@@ -113,7 +113,7 @@ class LTXVAddLatents:
 
     RETURN_TYPES = ("LATENT",)
     FUNCTION = "add_latents"
-    CATEGORY = "latent/video"
+    CATEGORY = "Lightricks/LTXV/Latent"
     DESCRIPTION = (
         "Concatenates two video latents along the frames dimension. "
         "latents1 and latents2 must have the same dimensions except for the frames dimension."
@@ -233,7 +233,7 @@ class LTXVSetVideoLatentNoiseMasks:
 
     RETURN_TYPES = ("LATENT",)
     FUNCTION = "set_mask"
-    CATEGORY = "latent/video"
+    CATEGORY = "Lightricks/LTXV/Latent"
     DESCRIPTION = (
         "Applies multiple masks to a video latent. "
         "masks can be 2D, 3D, or 4D tensors. "
@@ -351,7 +351,7 @@ class LTXVDilateLatent:
 
     RETURN_TYPES = ("LATENT",)
     FUNCTION = "dilate_latent"
-    CATEGORY = "latent/video"
+    CATEGORY = "Lightricks/LTXV/Latent"
     DESCRIPTION = "Dilates a latent by a grid size."
 
     def dilate_latent(
@@ -426,7 +426,7 @@ class LTXVAddLatentGuide:
     RETURN_TYPES = ("CONDITIONING", "CONDITIONING", "LATENT")
     RETURN_NAMES = ("positive", "negative", "latent")
 
-    CATEGORY = "ltxtricks"
+    CATEGORY = "Lightricks/LTXV/Guidance"
     FUNCTION = "generate"
 
     DESCRIPTION = "Adds a keyframe or a video segment at a specific frame index."
@@ -509,7 +509,7 @@ class LTXVImgToVideoConditionOnly:
 
     RETURN_TYPES = ("LATENT",)
     RETURN_NAMES = ("latent",)
-    CATEGORY = "conditioning/video_models"
+    CATEGORY = "Lightricks/LTXV/Conditioning"
     FUNCTION = "generate"
     DESCRIPTION = (
         "Applies image conditioning to the first frames of an existing latent. "
@@ -663,7 +663,7 @@ class LTXVSetAudioVideoMaskByTime:
     )
 
     FUNCTION = "run"
-    CATEGORY = "utility"
+    CATEGORY = "Lightricks/LTXV/Masking"
     DESCRIPTION = "Sets the audio and video mask by time."
 
     def run(

--- a/looping_sampler.py
+++ b/looping_sampler.py
@@ -236,7 +236,7 @@ class LTXVLoopingSampler:
     RETURN_NAMES = ("denoised_output",)
 
     FUNCTION = "sample"
-    CATEGORY = "sampling"
+    CATEGORY = "Lightricks/LTXV/Sampling"
 
     def _extract_latent_spatial_tile(self, latent_dict, v_start, v_end, h_start, h_end):
         """Extract spatial tile from a latent dictionary."""
@@ -962,7 +962,7 @@ class MultiPromptProvider:
     RETURN_NAMES = ("conditionings",)
 
     FUNCTION = "get_prompt_list"
-    CATEGORY = "prompt"
+    CATEGORY = "Lightricks/LTXV/Conditioning"
 
     def get_prompt_list(self, prompts, clip):
         prompt_list = prompts.split("|")

--- a/low_vram_loaders.py
+++ b/low_vram_loaders.py
@@ -40,7 +40,7 @@ class LowVRAMCheckpointLoader(nodes.CheckpointLoaderSimple):
         }
         return base_types
 
-    CATEGORY = "LTXV/loaders"
+    CATEGORY = "Lightricks/LTXV/Loaders"
     DESCRIPTION = (
         "Loads a diffusion model checkpoint with dependency support. "
         "Connect 'dependencies' to a previous loader's output to ensure sequential loading and reduce peak VRAM usage."
@@ -79,7 +79,7 @@ class LowVRAMAudioVAELoader:
 
     RETURN_TYPES = ("VAE",)
     RETURN_NAMES = ("audio_vae",)
-    CATEGORY = "LTXV/loaders"
+    CATEGORY = "Lightricks/LTXV/Loaders"
     DESCRIPTION = (
         "Loads an LTXV Audio VAE checkpoint with dependency support. "
         "Connect 'dependencies' to a previous loader's output to ensure sequential loading and reduce peak VRAM usage."
@@ -105,7 +105,7 @@ class LowVRAMLatentUpscaleModelLoader(LatentUpscaleModelLoader):
         return io.Schema(
             node_id="LowVRAMLatentUpscaleModelLoader",
             display_name="Low VRAMLoad Latent Upscale Model",
-            category="LTXV/loaders",
+            category="Lightricks/LTXV/Loaders",
             inputs=[
                 io.Combo.Input(
                     "model_name",

--- a/masks.py
+++ b/masks.py
@@ -96,7 +96,7 @@ class LTXVPreprocessMasks:
 
     RETURN_TYPES = ("MASK",)
     FUNCTION = "preprocess_masks"
-    CATEGORY = "Lightricks/mask_operations"
+    CATEGORY = "Lightricks/LTXV/Masking"
     DESCRIPTION = (
         "Preprocess masks to be used for masking latents in the LTXVideo model."
     )

--- a/prompt_enhancer_nodes.py
+++ b/prompt_enhancer_nodes.py
@@ -87,7 +87,7 @@ class LTXVPromptEnhancerLoader:
     RETURN_TYPES = ("LTXV_PROMPT_ENHANCER",)
     RETURN_NAMES = ("prompt_enhancer",)
     FUNCTION = "load"
-    CATEGORY = "lightricks/LTXV"
+    CATEGORY = "Lightricks/LTXV/Loaders"
     TITLE = "LTXV Prompt Enhancer (Down)Loader"
     OUTPUT_NODE = False
     DESCRIPTION = "Downloads and initializes LLM and image captioning models from Hugging Face to enhance text prompts for image generation."
@@ -178,7 +178,7 @@ class LTXVPromptEnhancer:
     RETURN_TYPES = ("STRING",)
     RETURN_NAMES = ("str",)
     FUNCTION = "enhance"
-    CATEGORY = "lightricks/LTXV"
+    CATEGORY = "Lightricks/LTXV/Conditioning"
     TITLE = "LTXV Prompt Enhancer"
     OUTPUT_NODE = False
     DESCRIPTION = (

--- a/q8_nodes.py
+++ b/q8_nodes.py
@@ -63,7 +63,7 @@ class LTXVQ8Patch:
 
     RETURN_TYPES = ("MODEL",)
     FUNCTION = "patch"
-    CATEGORY = "lightricks/LTXV"
+    CATEGORY = "Lightricks/LTXV/Model Patches"
     TITLE = "LTXV Q8 Patcher"
     PRESETS = {
         "0.9.8": (True, True, True),
@@ -135,7 +135,7 @@ class LTXVQ8LoraModelLoader:
         }
 
     RETURN_TYPES = ("MODEL",)
-    CATEGORY = "lightricks/LTXV"
+    CATEGORY = "Lightricks/LTXV/Loaders"
     FUNCTION = "load_lora_model_only"
 
     def load_lora(self, model, lora_name, strength_model):

--- a/stg.py
+++ b/stg.py
@@ -94,7 +94,7 @@ class LTXVApplySTG:
     FUNCTION = "apply_stg"
     RETURN_TYPES = ("MODEL",)
     RETURN_NAMES = ("model",)
-    CATEGORY = "lightricks/LTXV"
+    CATEGORY = "Lightricks/LTXV/Model Patches"
 
     DESCRIPTION = "Defines the blocks to apply the STG to."
 
@@ -523,7 +523,7 @@ class STGGuiderNode:
     RETURN_TYPES = ("GUIDER",)
 
     FUNCTION = "get_guider"
-    CATEGORY = "lightricks/LTXV"
+    CATEGORY = "Lightricks/LTXV/Guidance"
 
     DESCRIPTION = (
         "Implements Spatiotemporal Skip Guidance (STG), a training-free method enhancing transformer-based "
@@ -648,7 +648,7 @@ class STGGuiderAdvancedNode:
     RETURN_TYPES = ("GUIDER",)
 
     FUNCTION = "get_guider"
-    CATEGORY = "lightricks/LTXV"
+    CATEGORY = "Lightricks/LTXV/Guidance"
     DESCRIPTION = """
     The Advanced STG Guider implements sophisticated techniques for controlling the denoising process:
 
@@ -788,7 +788,7 @@ class STGAdvancedPresetsNode:
     RETURN_TYPES = ("STG_ADVANCED_PRESET",)
 
     FUNCTION = "get_preset"
-    CATEGORY = "lightricks/LTXV"
+    CATEGORY = "Lightricks/LTXV/Guidance"
 
     def get_preset(self, preset=None):
         return (preset,)
@@ -915,7 +915,7 @@ class APGGuiderNode:
     RETURN_TYPES = ("GUIDER",)
 
     FUNCTION = "get_guider"
-    CATEGORY = "lightricks/LTXV"
+    CATEGORY = "Lightricks/LTXV/Guidance"
 
     DESCRIPTION = """
     The APG Guider implements Adaptive Projected Guidance (APG).

--- a/tiled_sampler.py
+++ b/tiled_sampler.py
@@ -56,7 +56,7 @@ class LTXVTiledSampler:
 
     FUNCTION = "sample"
 
-    CATEGORY = "sampling"
+    CATEGORY = "Lightricks/LTXV/Sampling"
 
     def sample(
         self,

--- a/tiled_vae_decode.py
+++ b/tiled_vae_decode.py
@@ -32,7 +32,7 @@ class LTXVTiledVAEDecode:
 
     FUNCTION = "decode"
 
-    CATEGORY = "latent"
+    CATEGORY = "Lightricks/LTXV/Latent"
 
     def decode(
         self,
@@ -344,7 +344,7 @@ class LTXVSpatioTemporalTiledVAEDecode(LTXVTiledVAEDecode):
 
     FUNCTION = "decode_spatial_temporal"
 
-    CATEGORY = "latent"
+    CATEGORY = "Lightricks/LTXV/Latent"
 
     def decode_spatial_temporal(
         self,

--- a/tricks/nodes/attn_bank_nodes.py
+++ b/tricks/nodes/attn_bank_nodes.py
@@ -14,7 +14,7 @@ class LTXAttentionBankNode:
     RETURN_TYPES = ("ATTN_BANK",)
     FUNCTION = "build"
 
-    CATEGORY = "ltxtricks"
+    CATEGORY = "Lightricks/LTXV/Model Patches"
 
     def build(self, save_steps, blocks=""):
         block_map = {}
@@ -48,7 +48,7 @@ class LTXPrepareAttnInjectionsNode:
     RETURN_TYPES = ("LATENT", "ATTN_INJ")
     FUNCTION = "prepare"
 
-    CATEGORY = "fluxtapoz"
+    CATEGORY = "Lightricks/LTXV/Model Patches"
 
     def prepare(self, latent, attn_bank, query, key, value, inject_steps, blocks=None):
         if inject_steps > attn_bank["save_steps"]:
@@ -82,7 +82,7 @@ class LTXAttentioOverrideNode:
     RETURN_TYPES = ("LTX_BLOCKS",)
     FUNCTION = "build"
 
-    CATEGORY = "ltxtricks"
+    CATEGORY = "Lightricks/LTXV/Model Patches"
 
     def build(self, blocks=""):
         block_set = set(list(int(block) for block in blocks.split(",")))

--- a/tricks/nodes/attn_override_node.py
+++ b/tricks/nodes/attn_override_node.py
@@ -18,7 +18,7 @@ class LTXAttnOverrideNode:
     RETURN_TYPES = ("ATTN_OVERRIDE",)
     FUNCTION = "build"
 
-    CATEGORY = "ltxtricks/attn"
+    CATEGORY = "Lightricks/LTXV/Model Patches"
 
     def build(self, layers):
         layers_map = set([])

--- a/tricks/nodes/latent_guide_node.py
+++ b/tricks/nodes/latent_guide_node.py
@@ -17,7 +17,7 @@ class AddLatentGuideNode(nodes_lt.LTXVAddGuide):
     RETURN_TYPES = ("MODEL", "LATENT")
     RETURN_NAMES = ("model", "latent")
 
-    CATEGORY = "ltxtricks"
+    CATEGORY = "Lightricks/LTXV/Guidance"
     FUNCTION = "generate"
 
     def generate(self, model, latent, image_latent, index, strength):

--- a/tricks/nodes/ltx_feta_enhance_node.py
+++ b/tricks/nodes/ltx_feta_enhance_node.py
@@ -19,7 +19,7 @@ class LTXFetaEnhanceNode:
 
     RETURN_TYPES = ("MODEL",)
 
-    CATEGORY = "ltxtricks"
+    CATEGORY = "Lightricks/LTXV/Model Patches"
     FUNCTION = "apply"
 
     def apply(self, model, feta_weight, attn_override=DEFAULT_ATTN):

--- a/tricks/nodes/ltx_flowedit_nodes.py
+++ b/tricks/nodes/ltx_flowedit_nodes.py
@@ -55,7 +55,7 @@ class LTXFlowEditCFGGuiderNode:
     RETURN_TYPES = ("GUIDER",)
 
     FUNCTION = "get_guider"
-    CATEGORY = "ltxtricks"
+    CATEGORY = "Lightricks/LTXV/Guidance"
 
     def get_guider(
         self,
@@ -173,7 +173,7 @@ class LTXFlowEditSamplerNode:
     RETURN_TYPES = ("SAMPLER",)
     FUNCTION = "build"
 
-    CATEGORY = "ltxtricks"
+    CATEGORY = "Lightricks/LTXV/Sampling"
 
     def build(self, skip_steps, refine_steps, seed):
         sampler = KSAMPLER(get_flowedit_sample(skip_steps, refine_steps, seed))

--- a/tricks/nodes/ltx_inverse_model_pred_nodes.py
+++ b/tricks/nodes/ltx_inverse_model_pred_nodes.py
@@ -30,7 +30,7 @@ class LTXForwardModelSamplingPredNode:
     RETURN_TYPES = ("MODEL",)
     FUNCTION = "patch"
 
-    CATEGORY = "ltxtricks"
+    CATEGORY = "Lightricks/LTXV/Prediction"
 
     def patch(self, model):
         m = model.clone()
@@ -74,7 +74,7 @@ class LTXReverseModelSamplingPredNode:
     RETURN_TYPES = ("MODEL",)
     FUNCTION = "patch"
 
-    CATEGORY = "ltxtricks"
+    CATEGORY = "Lightricks/LTXV/Prediction"
 
     def patch(self, model):
         m = model.clone()

--- a/tricks/nodes/ltx_pag_node.py
+++ b/tricks/nodes/ltx_pag_node.py
@@ -79,7 +79,7 @@ class LTXPerturbedAttentionNode:
     RETURN_TYPES = ("MODEL",)
     FUNCTION = "patch"
 
-    CATEGORY = "ltxtricks/attn"
+    CATEGORY = "Lightricks/LTXV/Model Patches"
 
     def patch(
         self, model, scale, rescale, cfg, attn_override=DEFAULT_PAG_LTX, attn_type="PAG"

--- a/tricks/nodes/modify_ltx_model_node.py
+++ b/tricks/nodes/modify_ltx_model_node.py
@@ -12,7 +12,7 @@ class ModifyLTXModelNode:
 
     RETURN_TYPES = ("MODEL",)
 
-    CATEGORY = "ltxtricks"
+    CATEGORY = "Lightricks/LTXV/Model Patches"
     FUNCTION = "modify"
 
     def modify(self, model):

--- a/tricks/nodes/rectified_sampler_nodes.py
+++ b/tricks/nodes/rectified_sampler_nodes.py
@@ -194,7 +194,7 @@ class LTXRFForwardODESamplerNode:
     RETURN_TYPES = ("SAMPLER",)
     FUNCTION = "build"
 
-    CATEGORY = "ltxtricks"
+    CATEGORY = "Lightricks/LTXV/Sampling"
 
     def build(
         self,
@@ -245,7 +245,7 @@ class LTXRFReverseODESamplerNode:
     RETURN_TYPES = ("SAMPLER",)
     FUNCTION = "build"
 
-    CATEGORY = "ltxtricks"
+    CATEGORY = "Lightricks/LTXV/Sampling"
 
     def build(
         self,

--- a/tricks/nodes/rf_edit_sampler_nodes.py
+++ b/tricks/nodes/rf_edit_sampler_nodes.py
@@ -172,7 +172,7 @@ class FlowEditForwardSamplerNode:
     RETURN_TYPES = ("SAMPLER", "ATTN_INJ")
     FUNCTION = "build"
 
-    CATEGORY = "fluxtapoz"
+    CATEGORY = "Lightricks/LTXV/Sampling"
 
     def build(
         self,
@@ -307,7 +307,7 @@ class FlowEdit2ReverseSamplerNode:
     RETURN_TYPES = ("SAMPLER",)
     FUNCTION = "build"
 
-    CATEGORY = "ltxtricks"
+    CATEGORY = "Lightricks/LTXV/Sampling"
 
     def build(
         self,
@@ -335,7 +335,7 @@ class PrepareAttnBankNode:
     RETURN_TYPES = ("LATENT", "ATTN_INJ")
     FUNCTION = "prepare"
 
-    CATEGORY = "ltxtricks"
+    CATEGORY = "Lightricks/LTXV/Model Patches"
 
     def prepare(self, latent, attn_inj):
         # Hack to force order of operations in ComfyUI graph
@@ -353,7 +353,7 @@ class RFSingleBlocksOverrideNode:
     RETURN_TYPES = ("SINGLE_LAYERS",)
     FUNCTION = "build"
 
-    CATEGORY = "ltxtricks"
+    CATEGORY = "Lightricks/LTXV/Model Patches"
 
     def build(self, *args, **kwargs):
         return (kwargs,)
@@ -370,7 +370,7 @@ class RFDoubleBlocksOverrideNode:
     RETURN_TYPES = ("DOUBLE_LAYERS",)
     FUNCTION = "build"
 
-    CATEGORY = "ltxtricks"
+    CATEGORY = "Lightricks/LTXV/Model Patches"
 
     def build(self, *args, **kwargs):
         return (kwargs,)

--- a/utiltily_nodes.py
+++ b/utiltily_nodes.py
@@ -47,7 +47,7 @@ class ImageToCPU:
 
     RETURN_TYPES = ("IMAGE",)
     FUNCTION = "run"
-    CATEGORY = "utility"
+    CATEGORY = "Lightricks/LTXV/Utility"
 
     def run(self, image):
         return (image.cpu(),)

--- a/vae_patcher.py
+++ b/vae_patcher.py
@@ -15,7 +15,7 @@ class LTXVPatcherVAE:
 
     RETURN_TYPES = ("VAE",)
     FUNCTION = "patch"
-    CATEGORY = "lightricks/LTXV"
+    CATEGORY = "Lightricks/LTXV/Model Patches"
     TITLE = "LTXV VAE Patcher"
 
     def patch(self, vae):


### PR DESCRIPTION
![ltxvideo](https://github.com/user-attachments/assets/87fe6522-8719-4cda-be98-f96c87344909)

# Unify and organize node categories under Lightricks/LTXV

## Summary
This pull request refactors the node category structure to provide a unified, consistent, and functionally-grouped hierarchy for all nodes in the ComfyUI-LTXVideo custom node set.

## Motivation
The existing node categories were fragmented and inconsistent, using various prefixes and top-level names such as `lightricks/LTXV`, `ltxtricks`, `latent`, `fluxtapoz`, and `sampling`. This inconsistency made it difficult for users to locate specific nodes within the ComfyUI right-click menu.

This change aims to significantly improve the user experience by consolidating all nodes under a clear `Lightricks/LTXV` root, with logical sub-categories based on their function.

## Changes
All nodes have been moved to a new, standardized hierarchy under the `Lightricks/LTXV` root. The new structure groups nodes by their primary function:

| New Category | Description | Example Nodes |
| :--- | :--- | :--- |
| `Lightricks/LTXV/Loaders` | Model, checkpoint, LoRA, and conditioning loaders. | `LTXVGemmaCLIPModelLoader`, `LTXICLoRALoaderModelOnly` |
| `Lightricks/LTXV/Sampling` | Samplers and core sampling logic nodes. | `LTXVBaseSampler`, `LTXVTiledSampler`, `LTXFlowEditSamplerNode` |
| `Lightricks/LTXV/Conditioning` | Prompt encoding, enhancement, and conditioning nodes. | `LTXVGemmaEnhancePrompt`, `DynamicConditioning`, `GemmaAPITextEncode` |
| `Lightricks/LTXV/Latent` | Latent manipulation, VAE decoding, and normalization. | `LTXVTiledVAEDecode`, `LTXVAdainLatent`, `DecoderNoise` |
| `Lightricks/LTXV/Masking` | Mask creation and processing nodes. | `LTXVPreprocessMasks`, `LTXVSetAudioVideoMaskByTime` |
| `Lightricks/LTXV/Model Patches` | Nodes that modify the core model (e.g., Q8, VAE patchers, attention overrides). | `LTXVApplySTG`, `LTXVPatcherVAE`, `ModifyLTXModelNode` |
| `Lightricks/LTXV/Guidance` | Guiders, advanced guide controls (STG, FlowEdit CFG), and guide application. | `STGGuiderNode`, `MultimodalGuiderNode`, `LTXAddVideoICLoRAGuide` |
| `Lightricks/LTXV/Prediction` | Model sampling prediction nodes. | `LTXForwardModelSamplingPredNode`, `LTXReverseModelSamplingPredNode` |
| `Lightricks/LTXV/Utility` | General utility and helper nodes. | `ImageToCPU`, `LinearOverlapLatentTransition` |

## Technical Notes
*   Consolidated internal/experimental categories (`ltxtricks`, `fluxtapoz`) into the new functional groups.
*   The change was applied to both the standard `CATEGORY` class attribute and the `category` field within `define_schema` methods (e.g., in `iclora.py`) to ensure full coverage.
*   A total of 68 node categories were modified.
