### PR TITLE
fix: UnboundLocalError for noise_pred_neg/perturbed when cfg=1.0

### DIFF
--- a/guiders/multimodal_guider.py
+++ b/guiders/multimodal_guider.py
@@ -158,6 +158,12 @@ class MultimodalGuider(comfy.samplers.CFGGuider):
         a_noise_pred_perturbed, v_noise_pred_perturbed = 0, 0
         a_noise_pred_modality, v_noise_pred_modality = 0, 0
 
+        # Initialize to noise_pred_pos as fallback for sampler_post_cfg_function hooks,
+        # which reference these unconditionally even when the conditional blocks below
+        # are skipped (e.g. cfg=1.0 distilled mode skips do_uncond, no STG skips do_perturbed).
+        noise_pred_neg = noise_pred_pos
+        noise_pred_perturbed = noise_pred_pos
+
         if any(params.do_uncond() for params in [audio_params, video_params]):
             try:
                 model_options["transformer_options"]["run_vx"] = run_vx


### PR DESCRIPTION
## Summary

Fixes `UnboundLocalError` in `MultimodalGuider.predict_noise()` when using cfg=1.0 (distilled mode) with `sampler_post_cfg_function` hooks active.

Fixes #458

## Bug

In `predict_noise()`, the variables `noise_pred_neg` and `noise_pred_perturbed` are only assigned inside conditional blocks:

- `noise_pred_neg` is assigned inside `if any(params.do_uncond() ...)` -- skipped when cfg=1.0
- `noise_pred_perturbed` is assigned inside `if any(params.do_perturbed() ...)` -- skipped when STG is disabled

However, both variables are **unconditionally referenced** later in the `sampler_post_cfg_function` hooks loop:

```python
for fn in model_options.get("sampler_post_cfg_function", []):
    args = {
        ...
        "uncond_denoised": noise_pred_neg,        # <-- UnboundLocalError
        "perturbed_cond_denoised": noise_pred_perturbed,  # <-- UnboundLocalError
    }
```

This causes an `UnboundLocalError` crash when any post-CFG hook is registered (e.g. from other custom nodes) and the model runs in distilled mode (cfg=1.0).

## Fix

Initialize both variables to `noise_pred_pos` as safe fallbacks **before** the conditional blocks:

```python
noise_pred_neg = noise_pred_pos
noise_pred_perturbed = noise_pred_pos
```

When cfg=1.0 and no perturbation is applied, the unconditional and perturbed predictions are semantically equivalent to the positive prediction, so `noise_pred_pos` is the correct fallback value.