### PR TITLE
fix(workflow): swap VAEDecodeTiled for VAEDecode in LTX-2.3 HDR ICLoRA example workflow

### DIFF
--- a/example_workflows/2.3/LTX-2.3_ICLoRA_HDR_Distilled.json
+++ b/example_workflows/2.3/LTX-2.3_ICLoRA_HDR_Distilled.json
@@ -1486,31 +1486,8 @@
       ]
     },
     {
-      "id": 5121,
-      "type": "Note",
-      "pos": [
-        -504.4601702780707,
-        2965.4285923622097
-      ],
-      "size": [
-        210,
-        88
-      ],
-      "flags": {},
-      "order": 10,
-      "mode": 0,
-      "inputs": [],
-      "outputs": [],
-      "properties": {},
-      "widgets_values": [
-        "in case of OOM use tile_size of 768\ntemporal size 16"
-      ],
-      "color": "#432",
-      "bgcolor": "#653"
-    },
-    {
       "id": 4851,
-      "type": "VAEDecodeTiled",
+      "type": "VAEDecode",
       "pos": [
         -518.1273243034602,
         3125.1032336912526
@@ -1534,42 +1511,6 @@
           "name": "vae",
           "type": "VAE",
           "link": 13619
-        },
-        {
-          "localized_name": "tile_size",
-          "name": "tile_size",
-          "type": "INT",
-          "widget": {
-            "name": "tile_size"
-          },
-          "link": null
-        },
-        {
-          "localized_name": "overlap",
-          "name": "overlap",
-          "type": "INT",
-          "widget": {
-            "name": "overlap"
-          },
-          "link": null
-        },
-        {
-          "localized_name": "temporal_size",
-          "name": "temporal_size",
-          "type": "INT",
-          "widget": {
-            "name": "temporal_size"
-          },
-          "link": null
-        },
-        {
-          "localized_name": "temporal_overlap",
-          "name": "temporal_overlap",
-          "type": "INT",
-          "widget": {
-            "name": "temporal_overlap"
-          },
-          "link": null
         }
       ],
       "outputs": [
@@ -1585,14 +1526,8 @@
       "properties": {
         "cnr_id": "comfy-core",
         "ver": "0.14.1",
-        "Node name for S&R": "VAEDecodeTiled"
-      },
-      "widgets_values": [
-        768,
-        256,
-        8,
-        4
-      ]
+        "Node name for S&R": "VAEDecode"
+      }
     },
     {
       "id": 5120,
@@ -2879,10 +2814,6 @@
       },
       "4851": {
         "inputs": {
-          "tile_size": 768,
-          "overlap": 256,
-          "temporal_size": 8,
-          "temporal_overlap": 4,
           "samples": [
             "5013",
             2
@@ -2892,9 +2823,9 @@
             2
           ]
         },
-        "class_type": "VAEDecodeTiled",
+        "class_type": "VAEDecode",
         "_meta": {
-          "title": "VAE Decode (Tiled)"
+          "title": "VAE Decode"
         }
       },
       "5011": {


### PR DESCRIPTION
## Summary
- The LTX-2.3 ICLoRA HDR Distilled example workflow currently uses `VAEDecodeTiled`, which produces a flickering / ghosting / strobing artifact in the output video (as reported by @boyan-orion in #470).
- Switching the single decode node to a plain `VAEDecode` resolves the issue.

## Changes
- `example_workflows/2.3/LTX-2.3_ICLoRA_HDR_Distilled.json`
  - Replace `VAEDecodeTiled` (node `4851`) with `VAEDecode`; preserve existing `samples` / `vae` / `IMAGE` connections.
  - Remove the now-obsolete `"in case of OOM use tile_size of 768 / temporal size 16"` Note node (`5121`), which only applied to the tiled decoder.

Minimal diff — +5/−74, no other nodes or links touched.

Fixes #470.

## Test plan
- [x] Load the modified workflow in ComfyUI — opens cleanly, `VAE Decode` is wired to `latent` + `vae` where the tiled node used to be, downstream `IMAGE` link intact.
- [x] Orange OOM note is gone.
- [ ] Run the workflow end-to-end on a representative prompt and confirm the flicker/ghosting artifacts are gone.