### PR TITLE
Fix ImportError: precompute_freqs_cis is now _precompute_freqs_cis on LTXBaseModel

### DIFF
--- a/tricks/modules/ltx_model.py
+++ b/tricks/modules/ltx_model.py
@@ -7,7 +7,6 @@ from comfy.ldm.lightricks.model import (
     BasicTransformerBlock,
     LTXVModel,
     apply_rotary_emb,
-    precompute_freqs_cis,
 )
 from comfy.ldm.lightricks.symmetric_patchifier import latent_to_pixel_coords
 from torch import nn
@@ -167,7 +166,7 @@ class LTXVModelModified(LTXVModel):
                 (attention_mask.shape[0], 1, -1, attention_mask.shape[-1])
             ) * torch.finfo(x.dtype).max
 
-        pe = precompute_freqs_cis(
+        pe = self._precompute_freqs_cis(
             fractional_coords, dim=self.inner_dim, out_dtype=x.dtype
         )
 


### PR DESCRIPTION
## Problem

The ComfyUI core recently refactored `precompute_freqs_cis` from a standalone function in `comfy.ldm.lightricks.model` to a private method `_precompute_freqs_cis` on the `LTXBaseModel` class.

This causes the following error when loading `ComfyUI-LTXVideo`:

```
ImportError: cannot import name 'precompute_freqs_cis' from 'comfy.ldm.lightricks.model'
```

## Fix

1. Removed `precompute_freqs_cis` from the import statement in `tricks/modules/ltx_model.py`
2. Changed the call site in `LTXVModelModified.forward()` from `precompute_freqs_cis(...)` to `self._precompute_freqs_cis(...)`

Since `LTXVModelModified` extends `LTXVModel` → `LTXBaseModel`, all required instance attributes (`split_positional_embedding`, `freq_grid_generator`) are available via `self`.

## Testing

Verified the module imports successfully in the target ComfyUI environment.