### PR TITLE
Remove try/except around internal import in __init__.py

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,4 @@
-    from . import internal  # noqa: F401
-except ImportError:
-    pass
+from . import internal  # noqa: F401
 from .conditioning_loader import LTXVLoadConditioning
 from .conditioning_saver import LTXVSaveConditioning
 from .decoder_noise import DecoderNoise


### PR DESCRIPTION
## Summary

Removes the `try: / except ImportError: pass` wrapper around `from . import internal` at the top of `__init__.py`.

The wrapper was introduced in the automated PR from 2026-05-11 (commit d50612a), but in the public repo the `try:` line is stripped out, leaving a `SyntaxError: unexpected indent` on import. Removing the wrapper entirely makes the public `__init__.py` valid Python again.

## Test plan
- [ ] `python -c "import importlib.util, pathlib; importlib.util.spec_from_file_location('m', pathlib.Path('__init__.py')).loader.exec_module"` no longer raises `IndentationError`
- [ ] ComfyUI starts cleanly with this custom node loaded (`Import times for custom nodes: … ComfyUI-LTXVideo` with no `IMPORT FAILED`)


Made with [Cursor](https://cursor.com)