### PR TITLE
Document LTX 2.3 text encoder download option

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,9 @@ Download the following models:
 **Distilled LoRA** - Required for current two-stage pipeline implementations in this repository (except DistilledPipeline and ICLoraPipeline). Download to `COMFYUI_ROOT_FOLDER/models/loras` folder.
   * [`ltx-2.3-22b-distilled-lora-384-1.1.safetensors`](https://huggingface.co/Lightricks/LTX-2.3/blob/main/ltx-2.3-22b-distilled-lora-384-1.1.safetensors)
 
-**Gemma Text Encoder** Download all files from the repository to `COMFYUI_ROOT_FOLDER/models/text_encoders/gemma-3-12b-it-qat-q4_0-unquantized`.
-  * [`Gemma 3`](https://huggingface.co/google/gemma-3-12b-it-qat-q4_0-unquantized)
+**Gemma Text Encoder** Download to `COMFYUI_ROOT_FOLDER/models/text_encoders`.
+  * [`Gemma 3`](https://huggingface.co/google/gemma-3-12b-it-qat-q4_0-unquantized) - download all files from the repository to `COMFYUI_ROOT_FOLDER/models/text_encoders/gemma-3-12b-it-qat-q4_0-unquantized`
+  * [`gemma_3_12B_it_fp8_scaled.safetensors`](https://huggingface.co/Comfy-Org/ltx-2/blob/main/split_files/text_encoders/gemma_3_12B_it_fp8_scaled.safetensors) - single-file ComfyUI text encoder option for LTX-2.3 workflows
 
 **LoRAs** Choose and download to `COMFYUI_ROOT_FOLDER/models/loras` folder.
   * [`ltx-2.3-22b-ic-lora-union-control-ref0.5.safetensors`](https://huggingface.co/Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control/blob/main/ltx-2.3-22b-ic-lora-union-control-ref0.5.safetensors)


### PR DESCRIPTION
Fixes #489.

## Summary
- add the Comfy-Org single-file Gemma text encoder link to the LTX-2.3 required models list
- clarify that the existing Google Gemma link requires downloading the full repository into the text encoder folder
- leave the LoRA list unchanged because the abliterated Gemma LoRA files are not required by the repository workflows

## Verification
- checked the LTX-2.3 workflow JSON files for their text encoder references
- verified the Comfy-Org text encoder file under `split_files/text_encoders`
- `git diff --check`

Implemented with Codex assistance; I reviewed the source links and kept the change to the docs-only model download list.
