### PR TITLE
Fix Kornia pad import compatibility

### DIFF
--- a/pyramid_blending.py
+++ b/pyramid_blending.py
@@ -10,7 +10,6 @@ from kornia.geometry.transform.pyramid import (
     build_pyramid,
     find_next_powerof_two,
     is_powerof_two,
-    pad,
 )
 from torch import Tensor
 
@@ -28,7 +27,7 @@ def _pad_for_laplacian(image: torch.Tensor) -> tuple[torch.Tensor, tuple[int, in
     if not (is_powerof_two(h) and is_powerof_two(w)):
         pad_right = find_next_powerof_two(w) - w
         pad_down = find_next_powerof_two(h) - h
-        image = pad(image, (0, pad_right, 0, pad_down), "reflect")
+        image = F.pad(image, (0, pad_right, 0, pad_down), mode="reflect")
     return image, (pad_right, pad_down)
 
 
@@ -41,7 +40,7 @@ def _gaussian_pyramid(
     h, w = images.shape[2], images.shape[3]
     if not (is_powerof_two(w) and is_powerof_two(h)):
         padding = (0, find_next_powerof_two(w) - w, 0, find_next_powerof_two(h) - h)
-        images = pad(images, padding, border_type)
+        images = F.pad(images, padding, mode=border_type)
     return build_pyramid(images, max_level, border_type, align_corners)
 
 


### PR DESCRIPTION
Fixes #496.

## Summary

- Removed the `pad` import from `kornia.geometry.transform.pyramid`.
- Reused the existing `torch.nn.functional as F` import for the two padding calls in `pyramid_blending.py`.

This keeps the local reflect padding behavior without depending on Kornia exporting `pad` from its pyramid module, which is what breaks on newer Kornia installs. It should also help the related `Cannot import name 'pad'` report in #494.

## Verification

- `python -m py_compile pyramid_blending.py`
- `git diff --check`

I did not run a full ComfyUI/Kornia runtime smoke locally because this machine does not have `torch` installed.

This was implemented with Codex assistance, with the patch kept focused and reviewed before opening.
