### PR TITLE
fix: remove unsupported APG momentum buffer argument

### DIFF
--- a/stg.py
+++ b/stg.py
@@ -461,7 +461,6 @@ class STGGuiderAdvanced(comfy.samplers.CFGGuider):
                 stg_result,
                 noise_pred_neg,
                 cfg_scale=self.apg_cfg_scale,
-                momentum_buffer=None,
                 eta=self.eta,
                 norm_threshold=self.norm_threshold,
             )


### PR DESCRIPTION
## Summary

Removes the unsupported `momentum_buffer=None` keyword from the `STGGuiderAdvanced` APG call.

`apg()` accepts `noise_pred_pos`, `noise_pred_neg`, `cfg_scale`, `eta`, and `norm_threshold`; passing `momentum_buffer` causes `apply_apg=True` sampling to fail immediately with the TypeError reported in #492.

## Verification

- `python -m py_compile stg.py`
- `git diff --check`

I did not run a full ComfyUI sampling workflow locally because this environment does not have the ComfyUI runtime/model stack installed.

Implemented with Codex assistance; I kept the patch focused and manually checked the reported call/signature mismatch.