### PR TITLE
fix: initialize multimodal guider post-hook fallbacks at cfg=1

### DIFF
--- a/guiders/multimodal_guider.py
+++ b/guiders/multimodal_guider.py
@@ -154,6 +154,9 @@ class MultimodalGuider(comfy.samplers.CFGGuider):
             del model_options["transformer_options"]["v2a_cross_attn"]
         v_noise_pred_pos, a_noise_pred_pos = self.unpack_latents(noise_pred_pos)
 
+        # When cfg=1 or stg=0 we still pass packed predictions through sampler_post_cfg hooks.
+        noise_pred_neg = noise_pred_pos
+        noise_pred_perturbed = noise_pred_pos
         a_noise_pred_neg, v_noise_pred_neg = 0, 0
         a_noise_pred_perturbed, v_noise_pred_perturbed = 0, 0
         a_noise_pred_modality, v_noise_pred_modality = 0, 0


### PR DESCRIPTION
﻿## Summary
- initialize packed negative and perturbed predictions from the positive prediction before optional CFG/STG branches
- keep the existing calculated values whenever unconditional or perturbed inference actually runs

## Problem
When both `do_uncond()` and `do_perturbed()` are false (for example cfg=1 and stg=0), `noise_pred_neg` and `noise_pred_perturbed` are never assigned. They are still added to the argument dictionary for every `sampler_post_cfg_function`, causing `UnboundLocalError` whenever such a hook is installed.

Using the positive prediction as the fallback preserves the no-guidance result and gives post-CFG hooks valid packed tensors on every control path.

## Validation
- rechecked the control flow against current upstream `master` (`ac4d998`); the uninitialized hook path is still present
- `py -m py_compile guiders/multimodal_guider.py`
- the PR remains limited to three initialization lines in the affected method
