### PR TITLE
fix: use torch padding for kornia 0.8 compatibility

### DIFF
--- a/pyramid_blending.py
+++ b/pyramid_blending.py
@@ -10,7 +10,6 @@ from kornia.geometry.transform.pyramid import (
     build_pyramid,
     find_next_powerof_two,
     is_powerof_two,
-    pad,
 )
 from torch import Tensor
 
@@ -28,7 +27,7 @@ def _pad_for_laplacian(image: torch.Tensor) -> tuple[torch.Tensor, tuple[int, in
     if not (is_powerof_two(h) and is_powerof_two(w)):
         pad_right = find_next_powerof_two(w) - w
         pad_down = find_next_powerof_two(h) - h
-        image = pad(image, (0, pad_right, 0, pad_down), "reflect")
+        image = F.pad(image, (0, pad_right, 0, pad_down), mode="reflect")
     return image, (pad_right, pad_down)
 
 
@@ -41,7 +40,7 @@ def _gaussian_pyramid(
     h, w = images.shape[2], images.shape[3]
     if not (is_powerof_two(w) and is_powerof_two(h)):
         padding = (0, find_next_powerof_two(w) - w, 0, find_next_powerof_two(h) - h)
-        images = pad(images, padding, border_type)
+        images = F.pad(images, padding, mode=border_type)
     return build_pyramid(images, max_level, border_type, align_corners)
 
 


### PR DESCRIPTION
﻿## Summary
- stop importing `pad` from Kornia's pyramid module
- use `torch.nn.functional.pad()` for the existing reflect-padding paths

## Problem
Kornia 0.8.3 no longer exports `pad` from `kornia.geometry.transform.pyramid`, so the current import prevents the node module from loading. PyTorch's functional `pad` provides the same padding operation already used here and avoids relying on Kornia's former internal re-export.

## Validation
- inspected the official `kornia-0.8.3-py3-none-any.whl`: `pyramid.py` has no exported `pad` function and its `__all__` excludes `pad`
- rechecked current upstream `master` (`ac4d998`); it still imports the removed symbol
- `py -m py_compile pyramid_blending.py`
- `git diff --check`
