### PR TITLE
Fix NaN output from LTXVAdainLatent

### DIFF
--- a/latent_norm.py
+++ b/latent_norm.py
@@ -43,6 +43,11 @@ class LTXVAdainLatent:
         latents_copy = copy.deepcopy(latents)
         t = latents_copy["samples"]  #  B x C x F x H x W
 
+        # Guard against division by a (near-)zero input std: a constant channel
+        # or frame yields i_sd == 0 -> 0/0 == NaN. LTXVStatNormLatent guards the
+        # same way (current_std > 1e-8).
+        eps = 1e-8
+
         if per_frame:
             if reference["samples"].size(2) == 1:
                 print("Reference has only one frame, using it for all frames")
@@ -61,15 +66,26 @@ class LTXVAdainLatent:
                     )  # index by original dim order
                     i_sd, i_mean = torch.std_mean(t[i, c], dim=None)
 
-                    t[i, c] = ((t[i, c] - i_mean) / i_sd) * r_sd + r_mean
+                    t[i, c] = ((t[i, c] - i_mean) / (i_sd + eps)) * r_sd + r_mean
                 else:
                     for f in range(t.size(2)):
                         r_sd, r_mean = torch.std_mean(
                             reference["samples"][i, c, f], dim=None
                         )  # index by original dim order
                         i_sd, i_mean = torch.std_mean(t[i, c, f], dim=None)
-                        t[i, c, f] = ((t[i, c, f] - i_mean) / i_sd) * r_sd + r_mean
+                        t[i, c, f] = (
+                            (t[i, c, f] - i_mean) / (i_sd + eps)
+                        ) * r_sd + r_mean
 
+        # torch.lerp(a, b, 0.0) is NOT a no-op when b holds NaN/Inf: 0 * NaN == NaN
+        # leaks through. Short-circuit factor == 0, and sanitize otherwise so a
+        # bad statistic can never propagate past the requested blend.
+        if factor == 0:
+            # t is latents_copy["samples"], mutated in place above; lerp(a, b, 0)
+            # == a, so return the untouched original.
+            latents_copy["samples"] = latents["samples"].clone()
+            return (latents_copy,)
+        t = torch.nan_to_num(t, nan=0.0, posinf=0.0, neginf=0.0)
         latents_copy["samples"] = torch.lerp(latents["samples"], t, factor)
         return (latents_copy,)
 


### PR DESCRIPTION
## Summary

`LTXVAdainLatent` can return NaN latents, which decode to blank output. Two independent causes, both fixed here:

**1. Division by a zero input std.** A constant channel — or a constant frame, in `per_frame` mode — gives `i_sd == 0`, so `(t - i_mean) / i_sd` is `0/0 == NaN`. Guarded with `eps = 1e-8`, matching the guard already present in `LTXVStatNormLatent` (`current_std > 1e-8`).

**2. NaN leaking through a zero blend.** `torch.lerp(a, b, 0.0)` is not a no-op when `b` holds NaN or Inf, because `0 * NaN == NaN`. So even `factor=0` — which the user has asked to mean "leave the input alone" — could return NaN. `factor == 0` now short-circuits and returns the untouched input; the non-zero path sanitizes with `nan_to_num` so a bad statistic cannot propagate past the requested blend.

## Motivation

Found while debugging blank audio-visual output from tiled generation, where every tile after the first decoded to nothing. The cause turned out to be case 1: a constant region in a latent tile produced NaN, which then propagated through the rest of the sampling chain.

The fix is not specific to that path — any `LTXVAdainLatent` use whose input contains a constant channel or frame hits case 1, and any use combining it with `factor=0` hits case 2.

## Notes

- Behavior is unchanged for well-conditioned inputs: `eps = 1e-8` is far below the scale of real latent standard deviations.
- `factor == 0` returning the input verbatim is what `lerp(a, b, 0)` already promised; this only makes it hold when `b` is contaminated.
- Extracted from #472 (AV latent support for the looping samplers), where this fix was originally made, so it can be reviewed and merged independently.

## Test plan

- [ ] Run `LTXVAdainLatent` with a reference latent containing a constant channel and confirm the output is finite (previously NaN).
- [ ] Same in `per_frame` mode with a constant frame.
- [ ] Confirm `factor=0` returns the input unchanged, including when the reference would produce a NaN statistic.
- [ ] Confirm a normal, well-conditioned AdaIn call produces output identical to before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
